### PR TITLE
Fixed issue in kmstools_enclave_cli format and improved readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,6 @@ At this point you should have the following ARNs from the previous steps:
     ]
 }
 ```
-# Do we also need to add the trust relationship for account and root?
 
 ### EC2 Instance Setup
 #### Bidding Service
@@ -243,7 +242,7 @@ sudo yum install -y aws-nitro-enclaves-cli aws-nitro-enclaves-cli-devel
 ```
 4. Allocate more memory to Nitro Enclaves by modifying /etc/nitro_enclaves/allocator.yaml:
 ```
-memory_mib: 2048
+memory_mib: 4096
 ```
 5. Run this command to allocate the memory
 ```
@@ -281,7 +280,10 @@ bucketBiddingService = "<Bidding Service BUCKET NAME>"
 instanceRoleARN = "<INSTANCE ROLE ARN>"
 ...
 ```
-Also remember to modify the AWS region in the file if you are not using the default region
+Also remember to modify the AWS region in the file if you are not using the default region.
+
+> For step 5 to 7, you can run `script/update_enclave.sh`.
+
 5. Build the container
 ```
 docker build -t vsock-poc .
@@ -327,12 +329,12 @@ Enclave Image successfully created.
 #### Bidding Service
 1. Start the Enclave in debug mode. In debug mode, you will beable to connect to the enclave's console to view its output for troubleshooting. Also the PCR0 value sent to KMS will be a series of zeroes used instead of the actual PCR0 value.
 ```
-sudo nitro-cli run-enclave --eif-path ~/vsock_poc.eif --cpu-count 2 --memory 2048 --debug-mode
+sudo nitro-cli run-enclave --eif-path ~/vsock_poc.eif --cpu-count 2 --memory 4096 --debug-mode
 ```
 If successful, you will see similar output below:
 ```
 Start allocating memory...
-Started enclave with enclave-cid: 19, memory: 2048 MiB, cpu-ids: [1, 5]
+Started enclave with enclave-cid: 19, memory: 4096 MiB, cpu-ids: [1, 5]
 {
   "EnclaveName": "vsock_poc",
   "EnclaveID": "i-0c3d696ac3c1f00dc-enc1802f51427d0db9",
@@ -343,7 +345,7 @@ Started enclave with enclave-cid: 19, memory: 2048 MiB, cpu-ids: [1, 5]
     1,
     5
   ],
-  "MemoryMiB": 2048
+  "MemoryMiB": 4096
 }
 ```
 Note the EnclaveID and EnclaveCID.
@@ -387,7 +389,7 @@ Successful S3 put_object response. Status - 200
 
 ### Running the Bidding Service Application in production mode
 #### Buyer1 and Buyer2
-1. Change the key policies to use the actual PCR measurement values generated from the enclave image.
+1. Change the key policies to use the actual PCR measurement values generated from the enclave image. 
 ```
 {
     "Sid": "Allow use of the key",
@@ -406,11 +408,11 @@ Successful S3 put_object response. Status - 200
     }
 }
 ```
-
+> You can run `script/generate_key_policy.sh` to generate the above policy with PCRs pre-filled. Remember to replace the `<INSTANCE ROLE ARN>` manually.
 #### Bidding Service
 1. Repeat the steps for running the bidding service application but remove the debug-mode flag. You will also not be able to connect to the enclave console.
 ```
-sudo nitro-cli run-enclave --eif-path ~/vsock_poc.eif --cpu-count 2 --memory 2048
+sudo nitro-cli run-enclave --eif-path ~/vsock_poc.eif --cpu-count 2 --memory 4096
 ```
 
 ## Security

--- a/scripts/generate_bidder_1_bids.sh
+++ b/scripts/generate_bidder_1_bids.sh
@@ -1,0 +1,9 @@
+read -p "Please provide your KMS Key ID:" KEYID
+
+echo "[].contract,[].bid" > encrypted.csv
+echo -n "1," >> encrypted.csv
+aws kms encrypt --key-id "${KEYID}" --cli-binary-format raw-in-base64-out --plaintext "100000" | jq -r ".CiphertextBlob" >> encrypted.csv
+echo -n "2," >> encrypted.csv
+aws kms encrypt --key-id "${KEYID}" --cli-binary-format raw-in-base64-out --plaintext "200000" | jq -r ".CiphertextBlob" >> encrypted.csv
+echo -n "3," >> encrypted.csv
+aws kms encrypt --key-id "${KEYID}" --cli-binary-format raw-in-base64-out --plaintext "150000" | jq -r ".CiphertextBlob" >> encrypted.csv

--- a/scripts/generate_bidder_2_bids.sh
+++ b/scripts/generate_bidder_2_bids.sh
@@ -1,0 +1,9 @@
+read -p "Please provide your KMS Key ID:" KEYID
+
+echo "[].contract,[].bid" > encrypted.csv
+echo -n "1," >> encrypted.csv
+aws kms encrypt --key-id "${KEYID}" --cli-binary-format raw-in-base64-out --plaintext "200000" | jq -r ".CiphertextBlob" >> encrypted.csv
+echo -n "2," >> encrypted.csv
+aws kms encrypt --key-id "${KEYID}" --cli-binary-format raw-in-base64-out --plaintext "300000" | jq -r ".CiphertextBlob" >> encrypted.csv
+echo -n "3," >> encrypted.csv
+aws kms encrypt --key-id "${KEYID}" --cli-binary-format raw-in-base64-out --plaintext "100000" | jq -r ".CiphertextBlob" >> encrypted.csv

--- a/scripts/generate_key_policy.sh
+++ b/scripts/generate_key_policy.sh
@@ -1,0 +1,22 @@
+PCR0=$(sudo nitro-cli describe-enclaves | jq -r .[0].Measurements.PCR0) 
+PCR1=$(sudo nitro-cli describe-enclaves | jq -r .[0].Measurements.PCR1) 
+PCR2=$(sudo nitro-cli describe-enclaves | jq -r .[0].Measurements.PCR2) 
+ 
+cat <<EOF  
+{ 
+    "Sid": "Allow use of the key", 
+    "Effect": "Allow", 
+    "Principal": { 
+        "AWS": "<INSTANCE ROLE ARN>" 
+    }, 
+    "Action": "kms:Decrypt", 
+    "Resource": "*", 
+    "Condition": { 
+        "StringEqualsIgnoreCase": { 
+            "kms:RecipientAttestation:ImageSha384": "${PCR0}", 
+            "kms:RecipientAttestation:PCR1":"${PCR1}", 
+            "kms:RecipientAttestation:PCR2":"${PCR2}" 
+        } 
+    } 
+} 
+EOF 

--- a/scripts/update_enclave.sh
+++ b/scripts/update_enclave.sh
@@ -1,0 +1,6 @@
+sudo nitro-cli terminate-enclave --all
+
+docker build -t vsock-poc .
+sudo nitro-cli build-enclave --docker-uri vsock-poc --output-file ~/vsock_poc.eif
+
+sudo nitro-cli run-enclave --eif-path ~/vsock_poc.eif --cpu-count 2 --memory 4096 --debug-mode

--- a/vsock-poc.py
+++ b/vsock-poc.py
@@ -21,6 +21,7 @@ bucketBuyer1 = ""
 bucketBuyer2 = ""
 bucketBiddingService = ""
 instanceRoleARN = ""
+region = "us-west-1"
 
 class VsockHandler:
     def __init__(self, cid, port, enclave):
@@ -146,7 +147,8 @@ class VsockListener:
         proc = subprocess.Popen(
             [
                 "/usr/src/app/kmstool_enclave_cli",
-                "--region", "us-west-2",
+                "decrypt",
+                "--region", region,
                 "--proxy-port", "8000",
                 "--aws-access-key-id", self.accessKey,
                 "--aws-secret-access-key", self.secretKey,
@@ -155,8 +157,11 @@ class VsockListener:
             ],
             stdout=subprocess.PIPE
         )
+
         plaintext = proc.communicate()[0].decode()
-        base64_bytes = plaintext.encode('ascii')
+        # plaintext's format is `PLAINTEXT: XXXXXXX`, extract the value
+        plaintext_content = plaintext.split(": ")[1]
+        base64_bytes = plaintext_content.encode('ascii')
         message_bytes = base64.b64decode(base64_bytes)
         message = message_bytes.decode('ascii')
         return message


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* `kmstools_enclave_cli` now takes different parameter and returns a different format, fixing `vsock-poc.py` to accomodate these changes. 
* Added some clarification and fixed a few typos in the README. Also added some scripts to speed up tedious steps in the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
