### PR TITLE
Clarify the need for trust policy and separate terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Note the EnclaveID and EnclaveCID.
 ```
 sudo nitro-cli console --enclave-id <EnclaveID>
 ```
-If you see similar output below, the application is ready to receive requests:
+This console will continuously print out the logs from inside the enclave. If you see similar output below, the application is ready to receive requests:
 ```
 ...
 [    0.807515] nsm: loading out-of-tree module taints kernel.
@@ -378,7 +378,7 @@ If you see similar output below, the application is ready to receive requests:
 [    0.812592] random: python3: uninitialized urandom read (24 bytes read)
 Starting VsockConnection
 ```
-3. Run the parent instance application
+3. Open another SSH session (or use a terminal multiplexer like [tmux](https://github.com/tmux/tmux/wiki) to create two separate terminals). Run the parent instance application
 ```
 python3 vsock-poc.py parent <EnclaveCID> 5005
 ```

--- a/README.md
+++ b/README.md
@@ -222,6 +222,22 @@ At this point you should have the following ARNs from the previous steps:
     ]
 }
 ```
+2. Follow these [instructions](https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-managingrole-editing-console.html#roles-managingrole_edit-trust-policy) to add the following trust policy to the IAM EC2 instance role:
+``` 
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ec2.amazonaws.com",
+                "AWS": "<INSTANCE ROLE ARN>"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+```
 
 ### EC2 Instance Setup
 #### Bidding Service


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Added description on how to set up trust policy for the EC2 instance role, so the python script can assume the role using STS SDK
- Clarify that the enclave console and client application need to be run in two separate terminals. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
